### PR TITLE
Run hab_load everytime you start zsh

### DIFF
--- a/hab.plugin.zsh
+++ b/hab.plugin.zsh
@@ -280,5 +280,5 @@ add-zsh-hook precmd __hab_reload
 # Completions
 complete -F __hab hab
 
-# Loads hab when openning a TMUX pane.
-[ -n "$TMUX" ] && __hab_load
+# Loads hab when starting zsh
+__hab_load


### PR DESCRIPTION
The idea is to run __hab_load whenever you open a new instance of zsh.

With this fix everytime you open a terminal on linux or vscode and you have a .envrc file there it will load it automatically. Before you needed to run cd . or hab load.